### PR TITLE
openvino-inference-engine: fix Python detection

### DIFF
--- a/recipes-core/opencv/files/0004-fix-python-detection.patch
+++ b/recipes-core/opencv/files/0004-fix-python-detection.patch
@@ -1,0 +1,82 @@
+From a1a97fe4ca9497069ac710f0f97614dfc5a46da0 Mon Sep 17 00:00:00 2001
+From: Anuj Mittal <anuj.mittal@intel.com>
+Date: Wed, 3 Jul 2024 14:21:13 +0800
+Subject: [PATCH] fix python detection
+
+OE-core installs python3-config without the prefixes so make sure we're
+able to use those.
+
+python3targetconfig class also allows using the target python config so
+we can use the right variables. We don't need tweaks to allow cmake to
+refer to host headers as well when looking for Python development
+modules. 
+
+Upstream-Status: Inappropriate
+
+Signed-off-by: Anuj Mittal <anuj.mittal@intel.com>
+---
+ .../cross_compile/python_helpers.cmake        | 40 ++++++++++---------
+ 1 file changed, 22 insertions(+), 18 deletions(-)
+
+diff --git a/cmake/developer_package/cross_compile/python_helpers.cmake b/cmake/developer_package/cross_compile/python_helpers.cmake
+index ad47bb68798..095c1e6f851 100644
+--- a/cmake/developer_package/cross_compile/python_helpers.cmake
++++ b/cmake/developer_package/cross_compile/python_helpers.cmake
+@@ -18,14 +18,18 @@ function(ov_detect_python_module_extension)
+         return()
+     endif()
+ 
+-    if(RISCV64)
+-        set(python3_config riscv64-linux-gnu-python3-config)
+-    elseif(AARCH64)
+-        set(python3_config aarch64-linux-gnu-python3-config)
+-    elseif(X86_64)
+-        set(python3_config python3-config)
++    if(NOT PYTHON3_CONFIG)
++        if(RISCV64)
++            set(python3_config riscv64-linux-gnu-python3-config)
++        elseif(AARCH64)
++            set(python3_config aarch64-linux-gnu-python3-config)
++        elseif(X86_64)
++            set(python3_config python3-config)
++        else()
++            message(WARNING "Python cross-compilation warning: ${OV_ARCH} is unknown for python build. Please, specify PYTHON_MODULE_EXTENSION explicitly")
++        endif()
+     else()
+-        message(WARNING "Python cross-compilation warning: ${OV_ARCH} is unknown for python build. Please, specify PYTHON_MODULE_EXTENSION explicitly")
++	set(python3_config ${PYTHON3_CONFIG})
+     endif()
+ 
+     find_host_program(python3_config_exec NAMES ${python3_config})
+@@ -55,20 +59,20 @@ macro(ov_find_python3 find_package_mode)
+         set(python3_development_component Development)
+     endif()
+ 
+-    if(CMAKE_CROSSCOMPILING AND LINUX)
+-        # allow to find python headers from host in case of cross-compilation
+-        # e.g. install libpython3-dev:<foreign arch> and finds its headers
+-        set(_old_CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ${CMAKE_FIND_ROOT_PATH_MODE_INCLUDE})
+-        set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE BOTH)
+-        ov_cross_compile_define_debian_arch()
+-    endif()
++    #if(CMAKE_CROSSCOMPILING AND LINUX)
++    #    # allow to find python headers from host in case of cross-compilation
++    #    # e.g. install libpython3-dev:<foreign arch> and finds its headers
++    #    set(_old_CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ${CMAKE_FIND_ROOT_PATH_MODE_INCLUDE})
++    #    set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE BOTH)
++    #    ov_cross_compile_define_debian_arch()
++    #endif()
+ 
+     find_package(Python3 ${find_package_mode} COMPONENTS Interpreter ${python3_development_component})
+ 
+-    if(CMAKE_CROSSCOMPILING AND LINUX)
+-        ov_cross_compile_define_debian_arch_reset()
+-        set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ${_old_CMAKE_FIND_ROOT_PATH_MODE_INCLUDE})
+-    endif()
++    #if(CMAKE_CROSSCOMPILING AND LINUX)
++    #    ov_cross_compile_define_debian_arch_reset()
++    #    set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ${_old_CMAKE_FIND_ROOT_PATH_MODE_INCLUDE})
++    #endif()
+ 
+     unset(python3_development_component)
+ endmacro()

--- a/recipes-core/opencv/openvino-inference-engine_2024.2.0.bb
+++ b/recipes-core/opencv/openvino-inference-engine_2024.2.0.bb
@@ -20,6 +20,7 @@ SRC_URI = "git://github.com/openvinotoolkit/openvino.git;protocol=https;name=ope
            file://0001-cmake-yocto-specific-tweaks-to-the-build-process.patch \
            file://0002-cmake-Fix-overloaded-virtual-error.patch \
            file://0003-protobuf-allow-target-protoc-to-be-built.patch \
+           file://0004-fix-python-detection.patch \
            "
 
 SRCREV_openvino = "5c0f38f83f62fdabcdc980fa6dc3ed1ea16c8a05"
@@ -53,7 +54,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327 \
                     file://thirdparty/telemetry/LICENSE;md5=86d3f3a95c324c9479bd8986968f4327 \
 "
 
-inherit cmake python3native pkgconfig qemu
+inherit cmake python3targetconfig pkgconfig qemu
 
 S = "${WORKDIR}/git"
 EXTRA_OECMAKE += " \
@@ -61,7 +62,6 @@ EXTRA_OECMAKE += " \
                   -DENABLE_OPENCV=OFF \
                   -DENABLE_INTEL_GNA=OFF \
                   -DENABLE_SYSTEM_TBB=ON \
-                  -DPYTHON_EXECUTABLE=${PYTHON} \
                   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
                   -DTHREADING=TBB -DTBB_DIR="${STAGING_LIBDIR}/cmake/TBB" \
                   -DTREAT_WARNING_AS_ERROR=FALSE \
@@ -76,6 +76,7 @@ EXTRA_OECMAKE += " \
                   -DENABLE_SYSTEM_SNAPPY=ON \
                   -DFETCHCONTENT_BASE_DIR="${S}" \
                   -DENABLE_INTEL_NPU=OFF \
+                  -DPYTHON3_CONFIG="python3-config" \
                   "
 EXTRA_OECMAKE:append:aarch64 = " -DARM_COMPUTE_LIB_DIR=${STAGING_LIBDIR} "
 
@@ -83,7 +84,6 @@ DEPENDS += "\
             flatbuffers-native \
             pugixml \
             python3-pybind11 \
-            python3-pybind11-native \
             python3-scons-native \
             qemu-native \
             snappy \
@@ -97,7 +97,7 @@ COMPATIBLE_HOST:libc-musl = "null"
 
 PACKAGECONFIG ?= "samples"
 PACKAGECONFIG[opencl] = "-DENABLE_INTEL_GPU=TRUE, -DENABLE_INTEL_GPU=FALSE, virtual/opencl-icd opencl-headers opencl-clhpp,"
-PACKAGECONFIG[python3] = "-DENABLE_PYTHON=ON -DPYTHON_LIBRARY=${PYTHON_LIBRARY} -DPYTHON_INCLUDE_DIR=${PYTHON_INCLUDE_DIR} -DENABLE_PYTHON_PACKAGING=ON, -DENABLE_PYTHON=OFF, patchelf-native, python3 python3-numpy python3-progress"
+PACKAGECONFIG[python3] = "-DENABLE_PYTHON=ON -DENABLE_PYTHON_PACKAGING=ON, -DENABLE_PYTHON=OFF, patchelf-native, python3 python3-numpy python3-progress"
 PACKAGECONFIG[samples] = "-DENABLE_SAMPLES=ON -DENABLE_COMPILE_TOOL=ON, -DENABLE_SAMPLES=OFF -DENABLE_COMPILE_TOOL=OFF, opencv"
 PACKAGECONFIG[verbose] = "-DVERBOSE_BUILD=1,-DVERBOSE_BUILD=0"
 


### PR DESCRIPTION
Prevent cmake from using native python3-config to derive values for module extensions. Use python3targetconfig and don't redefine other variables.