### PR TITLE
layer.conf : drop scarthgap from layer compatibility

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -14,7 +14,7 @@ LAYERDEPENDS_openvino = "core openembedded-layer meta-python"
 # This should only be incremented on significant changes that will
 # cause compatibility issues with other layers
 LAYERVERSION_openvino = "5"
-LAYERSERIES_COMPAT_openvino = "scarthgap styhead"
+LAYERSERIES_COMPAT_openvino = "styhead"
 
 require ${LAYERDIR}/conf/include/maintainers.inc
 


### PR DESCRIPTION
styhead is not compatible with scarthgap after
WORKDIR -> UNPACKDIR change