### PR TITLE
openvino-inference-engine : set a baseline policy version for cmake

### DIFF
--- a/recipes-core/opencv/openvino-inference-engine_2025.1.0.bb
+++ b/recipes-core/opencv/openvino-inference-engine_2025.1.0.bb
@@ -86,6 +86,7 @@ EXTRA_OECMAKE += " \
                   -DENABLE_INTEL_NPU=OFF \
                   -DPYTHON3_CONFIG="python3-config" \
                   -DENABLE_OV_JAX_FRONTEND=OFF \
+                  -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
                   "
 EXTRA_OECMAKE:append:aarch64 = " -DARM_COMPUTE_LIB_DIR=${STAGING_LIBDIR} "
 


### PR DESCRIPTION
Cmake upgrade to 4.0+ removes compatibility with versions older than 3.5 [1].

Set a baseline policy version for CMake using
CMAKE_POLICY_VERSION_MINIMUM variable until upstream source implements the fix.

[1] https://git.yoctoproject.org/poky/commit/?id=2c9a6b4a81b642fc3e6815aa83d1c9bafb56c7db