### PR TITLE
openvino-inference-engine: use system node-api-headers

### DIFF
--- a/recipes-core/opencv/files/0001-node-addon-use-system-node-api-headers.patch
+++ b/recipes-core/opencv/files/0001-node-addon-use-system-node-api-headers.patch
@@ -1,0 +1,72 @@
+From: Krzysztof Kepka <krzysztof.kepka@intel.com>
+Date: Mon, 9 Feb 2026 13:00:00 +0000
+Subject: [PATCH] node-addon: add option to use system Node.js API headers
+
+Add ENABLE_SYSTEM_NODE CMake option to use system-provided Node.js
+API headers instead of downloading them from GitHub during the build.
+This aligns with Linux distribution packaging best practices and
+follows the established pattern used for other system libraries
+(protobuf, zlib, ...).
+
+When ENABLE_SYSTEM_NODE is ON, CMake searches for node_api.h and
+js_native_api.h in standard system include paths. Falls back to the
+original FetchContent download method when OFF (default unchanged).
+
+This enables BitBake recipe to use nodejs package headers from
+meta-openembedded instead of fetching during build, reducing external
+dependencies and aligning with Yocto best practices.
+
+Upstream-Status: Pending
+Signed-off-by: Krzysztof Kepka <krzysztof.kepka@intel.com>
+---
+ src/bindings/js/node/CMakeLists.txt | 30 +++++++++++++++++++++++-------
+ 1 file changed, 23 insertions(+), 7 deletions(-)
+
+diff --git a/src/bindings/js/node/CMakeLists.txt b/src/bindings/js/node/CMakeLists.txt
+index 8035de0953..b8c8852fef 100644
+--- a/src/bindings/js/node/CMakeLists.txt
++++ b/src/bindings/js/node/CMakeLists.txt
+@@ -29,12 +29,28 @@ add_definitions(-DNAPI_VERSION=6)
+ 
+ include(FetchContent)
+ 
+-FetchContent_Declare(
+-    node-api-headers
+-    URL      https://github.com/nodejs/node-api-headers/archive/refs/tags/v1.1.0.tar.gz
+-    URL_HASH SHA256=70608bc1e6dddce280285f3462f18a106f687c0720a4b90893e1ecd86e5a8bbf
+-)
+-FetchContent_MakeAvailable(node-api-headers)
++option(ENABLE_SYSTEM_NODE "Use system-provided Node.js API headers instead of downloading" OFF)
++
++if(ENABLE_SYSTEM_NODE)
++    find_path(NODE_API_HEADERS_DIR
++        NAMES node_api.h js_native_api.h
++        PATH_SUFFIXES node
++    )
++    if(NOT NODE_API_HEADERS_DIR)
++        message(FATAL_ERROR
++            "System Node.js API headers not found. "
++            "Install the nodejs-dev package or set NODE_API_HEADERS_DIR manually.")
++    endif()
++    message(STATUS "Using system Node.js API headers from: ${NODE_API_HEADERS_DIR}")
++else()
++    FetchContent_Declare(
++        node-api-headers
++        URL      https://github.com/nodejs/node-api-headers/archive/refs/tags/v1.1.0.tar.gz
++        URL_HASH SHA256=70608bc1e6dddce280285f3462f18a106f687c0720a4b90893e1ecd86e5a8bbf
++    )
++    FetchContent_MakeAvailable(node-api-headers)
++    set(NODE_API_HEADERS_DIR "${node-api-headers_SOURCE_DIR}/include")
++endif()
+ 
+ FetchContent_Declare(
+     node-addon-api
+@@ -70,7 +86,7 @@ add_library(${PROJECT_NAME} SHARED
+ )
+ 
+ target_include_directories(${PROJECT_NAME} PRIVATE
+-    "${node-api-headers_SOURCE_DIR}/include"
++    "${NODE_API_HEADERS_DIR}"
+     "${node-addon-api_SOURCE_DIR}"
+     "${CMAKE_CURRENT_SOURCE_DIR}/.."
+ )

--- a/recipes-core/opencv/openvino-inference-engine_2025.4.2.bb
+++ b/recipes-core/opencv/openvino-inference-engine_2025.4.2.bb
@@ -9,10 +9,10 @@ SRC_URI = "git://github.com/openvinotoolkit/openvino.git;protocol=https;name=ope
            git://github.com/oneapi-src/oneDNN.git;protocol=https;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/src/plugins/intel_gpu/thirdparty/onednn_gpu;name=onednn;nobranch=1 \
            git://github.com/herumi/xbyak.git;protocol=https;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/thirdparty/xbyak;name=xbyak;branch=master \
            git://github.com/openvinotoolkit/mlas.git;protocol=https;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/src/plugins/intel_cpu/thirdparty/mlas;name=mlas;nobranch=1 \
-           git://github.com/nodejs/node-api-headers.git;protocol=https;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/node-api-headers-src;name=node-api-headers;nobranch=1 \
            git://github.com/nodejs/node-addon-api.git;protocol=https;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/node-addon-api-src;name=node-addon-api;nobranch=1 \
            git://github.com/openvinotoolkit/telemetry.git;protocol=https;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/thirdparty/telemetry;name=telemetry;nobranch=1;lfs=0 \
            git://github.com/openvinotoolkit/googletest.git;protocol=https;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/thirdparty/gtest/gtest;name=gtest;nobranch=1;lfs=0 \
+           file://0001-node-addon-use-system-node-api-headers.patch \
            file://0001-cmake-yocto-specific-tweaks-to-the-build-process.patch \
            file://0002-cmake-Fix-overloaded-virtual-error.patch \
            file://0001-Fix-dependencies-to-use-system.patch \
@@ -31,11 +31,10 @@ SRCREV_onednn = "29d64fe0ec0f1f20d7f80aa76630d58a6011a869"
 SRCREV_xbyak = "0d67fd1530016b7c56f3cd74b3fca920f4c3e2b4"
 SRCREV_gtest = "99760ac1776430f3df65947992bf4e8ebc0d7660"
 SRCREV_mlas = "d1bc25ec4660cddd87804fcf03b2411b5dfb2e94"
-SRCREV_node-api-headers = "1294543dc1487389acc9cf2371572f57e1eb797d"
 SRCREV_node-addon-api = "6babc960154752f686a7dca8e712991a976a754b"
 SRCREV_telemetry = "8abddc3dbc8beb04a39b5ea40cbba5020317102f"
 SRCREV_gtest = "99760ac1776430f3df65947992bf4e8ebc0d7660"
-SRCREV_FORMAT = "openvino_mkl_onednn_xbyak_ade_node-api-headers_node-addon-api_mlas_telemetry_gtest"
+SRCREV_FORMAT = "openvino_mkl_onednn_xbyak_ade_node-addon-api_mlas_telemetry_gtest"
 
 LICENSE = "Apache-2.0 & MIT & BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327 \
@@ -44,7 +43,6 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327 \
                     file://src/plugins/intel_cpu/thirdparty/mlas/LICENSE;md5=86d3f3a95c324c9479bd8986968f4327 \
                     file://src/plugins/intel_cpu/thirdparty/onednn/LICENSE;md5=3b64000f6e7d52516017622a37a94ce9 \
                     file://src/plugins/intel_gpu/thirdparty/onednn_gpu/LICENSE;md5=05fda7e0b3a0fe6749e8443316fc9a3f \
-                    file://node-api-headers-src/LICENSE;md5=6adb2909701d4605b4b2ae1a9b25d8bd \
                     file://node-addon-api-src/LICENSE.md;md5=fc3ff1120869be6b3cce17f9a06bfe2e \
                     file://thirdparty/telemetry/LICENSE;md5=86d3f3a95c324c9479bd8986968f4327 \
                     file://thirdparty/gtest/gtest/LICENSE;md5=cbbd27594afd089daa160d3a16dd515a \
@@ -107,6 +105,7 @@ PACKAGECONFIG ?= "samples"
 PACKAGECONFIG[itt] = "-DENABLE_PROFILING_ITT=BASE, -DENABLE_PROFILING_ITT=OFF, itt,"
 PACKAGECONFIG[opencl] = "-DENABLE_INTEL_GPU=TRUE, -DENABLE_INTEL_GPU=FALSE, virtual/libopencl1 opencl-headers opencl-clhpp,"
 PACKAGECONFIG[python3] = "-DENABLE_PYTHON=ON -DENABLE_PYTHON_PACKAGING=ON, -DENABLE_PYTHON=OFF, patchelf-native, python3 python3-numpy python3-progress"
+PACKAGECONFIG[node] = "-DENABLE_JS=ON -DENABLE_SYSTEM_NODE=ON,-DENABLE_JS=OFF, nodejs"
 PACKAGECONFIG[samples] = "-DENABLE_SAMPLES=ON -DENABLE_COMPILE_TOOL=ON, -DENABLE_SAMPLES=OFF -DENABLE_COMPILE_TOOL=OFF, opencv"
 PACKAGECONFIG[verbose] = "-DVERBOSE_BUILD=1,-DVERBOSE_BUILD=0"
 
@@ -128,6 +127,12 @@ do_install:append() {
     rm -rf ${D}${prefix}/setupvars.sh
 
     find ${B}/src/plugins/intel_cpu/cross-compiled/ -type f -name *_disp.cpp -exec sed -i -e 's%'"${S}"'%'"${TARGET_DBGSRC_DIR}"'%g' {} +
+
+    # Install the Node.js addon (excluded from cmake install by CPACK RPM packaging)
+    if [ -f ${S}/bin/intel64/ov_node_addon.node ]; then
+        install -d ${D}${libdir}
+        install -m 0755 ${S}/bin/intel64/ov_node_addon.node ${D}${libdir}/ov_node_addon.node
+    fi
 }
 
 # Otherwise e.g. ros-openvino-toolkit-dynamic-vino-sample when using dldt-inference-engine uses dldt-inference-engine WORKDIR
@@ -155,5 +160,12 @@ RDEPENDS:${PN}-samples += "python3-core"
 PACKAGES =+ "${PN}-python3"
 
 FILES:${PN}-python3 = "${PYTHON_SITEPACKAGES_DIR}"
+
+# Package for Node.js bindings
+PACKAGES =+ "${PN}-node"
+
+FILES:${PN}-node = "${libdir}/ov_node_addon.node"
+
+RDEPENDS:${PN}-node += "nodejs ${PN}"
 
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>(\d+\.\d+\.\d+))$"


### PR DESCRIPTION
Replace the bundled node-api-headers git submodule with system-provided headers from the nodejs package in meta-oe. This reduces external fetches during build and aligns with Yocto best practices for system dependencies.

- Add patch (ENABLE_SYSTEM_NODE CMake option) to use system Node.js API headers via find_path() instead of FetchContent download
- Remove node-api-headers from SRC_URI, SRCREV, SRCREV_FORMAT, and LIC_FILES_CHKSUM
- Add PACKAGECONFIG[node] for opt-in Node.js bindings (off by default)
- Add openvino-inference-engine-node subpackage (RDEPENDS: nodejs)
- Install ov_node_addon.node manually in do_install (upstream CMake excludes it from install via CPACK RPM packaging)