### PR TITLE
openvino-inference-engine: drop the duplicated line for SRCREV_gtest definition

### DIFF
--- a/recipes-core/opencv/openvino-inference-engine_2025.4.2.bb
+++ b/recipes-core/opencv/openvino-inference-engine_2025.4.2.bb
@@ -33,7 +33,6 @@ SRCREV_gtest = "99760ac1776430f3df65947992bf4e8ebc0d7660"
 SRCREV_mlas = "d1bc25ec4660cddd87804fcf03b2411b5dfb2e94"
 SRCREV_node-addon-api = "6babc960154752f686a7dca8e712991a976a754b"
 SRCREV_telemetry = "8abddc3dbc8beb04a39b5ea40cbba5020317102f"
-SRCREV_gtest = "99760ac1776430f3df65947992bf4e8ebc0d7660"
 SRCREV_FORMAT = "openvino_mkl_onednn_xbyak_ade_node-addon-api_mlas_telemetry_gtest"
 
 LICENSE = "Apache-2.0 & MIT & BSD-3-Clause"


### PR DESCRIPTION
For the  lines 32 and 36 of the file recipes-core/opencv/openvino-inference-engine_2025.4.2.bb
SRCREV_gtest is defined twice with the same value.

line 32: SRCREV_gtest = "99760ac1776430f3df65947992bf4e8ebc0d7660"
line 36: SRCREV_gtest = "99760ac1776430f3df65947992bf4e8ebc0d7660"

Here we just drop the duplicated line.