### PR TITLE
refactor(openvino-inference-engine): gate telemetry SRC_URI on python3 PACKAGECONFIG

### DIFF
--- a/recipes-core/opencv/openvino-inference-engine_2025.4.2.bb
+++ b/recipes-core/opencv/openvino-inference-engine_2025.4.2.bb
@@ -10,7 +10,6 @@ SRC_URI = "git://github.com/openvinotoolkit/openvino.git;protocol=https;name=ope
            git://github.com/herumi/xbyak.git;protocol=https;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/thirdparty/xbyak;name=xbyak;branch=master \
            git://github.com/openvinotoolkit/mlas.git;protocol=https;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/src/plugins/intel_cpu/thirdparty/mlas;name=mlas;nobranch=1 \
            git://github.com/nodejs/node-addon-api.git;protocol=https;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/node-addon-api-src;name=node-addon-api;nobranch=1 \
-           git://github.com/openvinotoolkit/telemetry.git;protocol=https;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/thirdparty/telemetry;name=telemetry;nobranch=1;lfs=0 \
            git://github.com/openvinotoolkit/googletest.git;protocol=https;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/thirdparty/gtest/gtest;name=gtest;nobranch=1;lfs=0 \
            file://0001-node-addon-use-system-node-api-headers.patch \
            file://0001-cmake-yocto-specific-tweaks-to-the-build-process.patch \
@@ -32,8 +31,7 @@ SRCREV_xbyak = "0d67fd1530016b7c56f3cd74b3fca920f4c3e2b4"
 SRCREV_gtest = "99760ac1776430f3df65947992bf4e8ebc0d7660"
 SRCREV_mlas = "d1bc25ec4660cddd87804fcf03b2411b5dfb2e94"
 SRCREV_node-addon-api = "6babc960154752f686a7dca8e712991a976a754b"
-SRCREV_telemetry = "8abddc3dbc8beb04a39b5ea40cbba5020317102f"
-SRCREV_FORMAT = "openvino_mkl_onednn_xbyak_ade_node-addon-api_mlas_telemetry_gtest"
+SRCREV_FORMAT = "openvino_mkl_onednn_xbyak_ade_node-addon-api_mlas_gtest"
 
 LICENSE = "Apache-2.0 & MIT & BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327 \
@@ -43,7 +41,6 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327 \
                     file://src/plugins/intel_cpu/thirdparty/onednn/LICENSE;md5=3b64000f6e7d52516017622a37a94ce9 \
                     file://src/plugins/intel_gpu/thirdparty/onednn_gpu/LICENSE;md5=05fda7e0b3a0fe6749e8443316fc9a3f \
                     file://node-addon-api-src/LICENSE.md;md5=fc3ff1120869be6b3cce17f9a06bfe2e \
-                    file://thirdparty/telemetry/LICENSE;md5=86d3f3a95c324c9479bd8986968f4327 \
                     file://thirdparty/gtest/gtest/LICENSE;md5=cbbd27594afd089daa160d3a16dd515a \
 "
 
@@ -108,6 +105,15 @@ PACKAGECONFIG[python3] = "-DENABLE_PYTHON=ON -DENABLE_PYTHON_PACKAGING=ON, -DENA
 PACKAGECONFIG[node] = "-DENABLE_JS=ON -DENABLE_SYSTEM_NODE=ON,-DENABLE_JS=OFF, nodejs"
 PACKAGECONFIG[samples] = "-DENABLE_SAMPLES=ON -DENABLE_COMPILE_TOOL=ON, -DENABLE_SAMPLES=OFF -DENABLE_COMPILE_TOOL=OFF, opencv"
 PACKAGECONFIG[verbose] = "-DVERBOSE_BUILD=1,-DVERBOSE_BUILD=0"
+
+SRC_URI += "${@bb.utils.contains('PACKAGECONFIG', 'python3', \
+    'git://github.com/openvinotoolkit/telemetry.git;protocol=https;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/thirdparty/telemetry;name=telemetry;nobranch=1;lfs=0', \
+    '', d)}"
+SRCREV_telemetry = "8abddc3dbc8beb04a39b5ea40cbba5020317102f"
+SRCREV_FORMAT .= "${@bb.utils.contains('PACKAGECONFIG', 'python3', '_telemetry', '', d)}"
+LIC_FILES_CHKSUM += "${@bb.utils.contains('PACKAGECONFIG', 'python3', \
+    'file://thirdparty/telemetry/LICENSE;md5=86d3f3a95c324c9479bd8986968f4327', \
+    '', d)}"
 
 do_configure:prepend() {
     # Note if no threading backend is selected in PACKAGECONFIG


### PR DESCRIPTION
The telemetry submodule is a Python package only used when building the OpenVINO Python bindings (src/bindings/python/CMakeLists.txt installs it as openvino-telemetry alongside the Python API).

Move the telemetry git source, SRCREV, SRCREV_FORMAT entry, and LIC_FILES_CHKSUM out of unconditional recipe metadata into bb.utils.contains guards on PACKAGECONFIG[python3].

When python3 is not enabled (the default), the source is not fetched.