### PR TITLE
refactor(openvino-inference-engine): gate node-addon-api SRC_URI on node PACKAGECONFIG

### DIFF
--- a/recipes-core/opencv/openvino-inference-engine_2025.4.2.bb
+++ b/recipes-core/opencv/openvino-inference-engine_2025.4.2.bb
@@ -9,9 +9,7 @@ SRC_URI = "git://github.com/openvinotoolkit/openvino.git;protocol=https;name=ope
            git://github.com/oneapi-src/oneDNN.git;protocol=https;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/src/plugins/intel_gpu/thirdparty/onednn_gpu;name=onednn;nobranch=1 \
            git://github.com/herumi/xbyak.git;protocol=https;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/thirdparty/xbyak;name=xbyak;branch=master \
            git://github.com/openvinotoolkit/mlas.git;protocol=https;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/src/plugins/intel_cpu/thirdparty/mlas;name=mlas;nobranch=1 \
-           git://github.com/nodejs/node-addon-api.git;protocol=https;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/node-addon-api-src;name=node-addon-api;nobranch=1 \
            git://github.com/openvinotoolkit/googletest.git;protocol=https;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/thirdparty/gtest/gtest;name=gtest;nobranch=1;lfs=0 \
-           file://0001-node-addon-use-system-node-api-headers.patch \
            file://0001-cmake-yocto-specific-tweaks-to-the-build-process.patch \
            file://0002-cmake-Fix-overloaded-virtual-error.patch \
            file://0001-Fix-dependencies-to-use-system.patch \
@@ -30,8 +28,7 @@ SRCREV_onednn = "29d64fe0ec0f1f20d7f80aa76630d58a6011a869"
 SRCREV_xbyak = "0d67fd1530016b7c56f3cd74b3fca920f4c3e2b4"
 SRCREV_gtest = "99760ac1776430f3df65947992bf4e8ebc0d7660"
 SRCREV_mlas = "d1bc25ec4660cddd87804fcf03b2411b5dfb2e94"
-SRCREV_node-addon-api = "6babc960154752f686a7dca8e712991a976a754b"
-SRCREV_FORMAT = "openvino_mkl_onednn_xbyak_ade_node-addon-api_mlas_gtest"
+SRCREV_FORMAT = "openvino_mkl_onednn_xbyak_ade_mlas_gtest"
 
 LICENSE = "Apache-2.0 & MIT & BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327 \
@@ -40,7 +37,6 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327 \
                     file://src/plugins/intel_cpu/thirdparty/mlas/LICENSE;md5=86d3f3a95c324c9479bd8986968f4327 \
                     file://src/plugins/intel_cpu/thirdparty/onednn/LICENSE;md5=3b64000f6e7d52516017622a37a94ce9 \
                     file://src/plugins/intel_gpu/thirdparty/onednn_gpu/LICENSE;md5=05fda7e0b3a0fe6749e8443316fc9a3f \
-                    file://node-addon-api-src/LICENSE.md;md5=fc3ff1120869be6b3cce17f9a06bfe2e \
                     file://thirdparty/gtest/gtest/LICENSE;md5=cbbd27594afd089daa160d3a16dd515a \
 "
 
@@ -113,6 +109,16 @@ SRCREV_telemetry = "8abddc3dbc8beb04a39b5ea40cbba5020317102f"
 SRCREV_FORMAT .= "${@bb.utils.contains('PACKAGECONFIG', 'python3', '_telemetry', '', d)}"
 LIC_FILES_CHKSUM += "${@bb.utils.contains('PACKAGECONFIG', 'python3', \
     'file://thirdparty/telemetry/LICENSE;md5=86d3f3a95c324c9479bd8986968f4327', \
+    '', d)}"
+
+SRC_URI += "${@bb.utils.contains('PACKAGECONFIG', 'node', \
+    'git://github.com/nodejs/node-addon-api.git;protocol=https;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/node-addon-api-src;name=node-addon-api;nobranch=1 \
+     file://0001-node-addon-use-system-node-api-headers.patch', \
+    '', d)}"
+SRCREV_node-addon-api = "6babc960154752f686a7dca8e712991a976a754b"
+SRCREV_FORMAT .= "${@bb.utils.contains('PACKAGECONFIG', 'node', '_node-addon-api', '', d)}"
+LIC_FILES_CHKSUM += "${@bb.utils.contains('PACKAGECONFIG', 'node', \
+    'file://node-addon-api-src/LICENSE.md;md5=fc3ff1120869be6b3cce17f9a06bfe2e', \
     '', d)}"
 
 do_configure:prepend() {


### PR DESCRIPTION
Move the node-addon-api git submodule, its system node-api-headers patch, SRCREV, SRCREV_FORMAT entry, and LIC_FILES_CHKSUM out of the unconditional recipe metadata into bb.utils.contains guards on PACKAGECONFIG[node].

When node is not enabled (the default), the source is not fetched.