### PR TITLE
arm-compute-library: fix do_fetch failure due to SRCREV not on main b…

### DIFF
--- a/recipes-devtools/arm-compute-library/arm-compute-library_24.11.bb
+++ b/recipes-devtools/arm-compute-library/arm-compute-library_24.11.bb
@@ -4,12 +4,11 @@ LICENSE = "MIT & Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSES/Apache-2.0.txt;md5=b3fe88572da337dd5b13cafe9424e879 \
                     file://LICENSES/MIT.txt;md5=35f8944fae972976691f3483b0ac9dba \
                    "
-SRCBRANCH = "main"
 # Matches v${PV}
 SRCREV = "f44f09dfd263c2bb0238f4323e366a210e9d4aae"
 
 SRC_URI = " \
-    git://github.com/ARM-software/ComputeLibrary.git;branch=${SRCBRANCH};protocol=https \
+    git://github.com/ARM-software/ComputeLibrary.git;nobranch=1;protocol=https \
     file://arm-compute-library.pc.in \
     file://0001-SConstruct-Add-prefix-PREFIX-variables.patch \
 "


### PR DESCRIPTION
…ranch

SRCREV f44f09dfd263c2bb0238f4323e366a210e9d4aae corresponds to the v24.11 tag but is no longer reachable from the main branch. This causes bitbake fetcher to fail with:

  Unable to find revision f44f09dfd263c2bb0238f4323e366a210e9d4aae
  in branch main even from upstream

Verified by cloning https://github.com/ARM-software/ComputeLibrary.git:

  $ git branch --contains f44f09dfd263c2bb0238f4323e366a210e9d4aae
  (no output - commit is not on any branch)

  $ git ls-remote https://github.com/ARM-software/ComputeLibrary.git | grep v24.11
  f44f09dfd263c2bb0238f4323e366a210e9d4aae  refs/tags/v24.11

Remove SRCBRANCH variable and switch to nobranch=1 to skip branch validation since the commit is only reachable via the v24.11 tag.