### PR TITLE
openvino-inference-engine: add debug-size tuning for RelWithDebInfo

### DIFF
--- a/recipes-core/opencv/openvino-inference-engine_2025.4.2.bb
+++ b/recipes-core/opencv/openvino-inference-engine_2025.4.2.bb
@@ -38,11 +38,23 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327 \
 
 inherit cmake python3targetconfig pkgconfig qemu
 
+# Keep backward-compatible default, but allow local/distro overrides.
+OV_CMAKE_BUILD_TYPE ?= "RelWithDebInfo"
+
+# Keep full RelWithDebInfo debug info by default. Enable this to shrink
+# massive DWARF output from template-heavy compilation units.
+OV_REDUCE_DEBUG_INFO ?= "0"
+OV_RELWITHDEBINFO_TUNING = "${@bb.utils.contains('OV_REDUCE_DEBUG_INFO', '1', ' -g1 -fdebug-types-section', '', d)}"
+OV_RELWITHDEBINFO_C_FLAGS ?= "${FULL_OPTIMIZATION} -DNDEBUG${OV_RELWITHDEBINFO_TUNING}"
+OV_RELWITHDEBINFO_CXX_FLAGS ?= "${FULL_OPTIMIZATION} -DNDEBUG${OV_RELWITHDEBINFO_TUNING}"
+
 EXTRA_OECMAKE += " \
                   -DCMAKE_CROSSCOMPILING_EMULATOR=${WORKDIR}/qemuwrapper \
                   -DENABLE_OPENCV=OFF \
                   -DENABLE_INTEL_GNA=OFF \
-                  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+                  -DCMAKE_BUILD_TYPE=${OV_CMAKE_BUILD_TYPE} \
+                  -DCMAKE_C_FLAGS_RELWITHDEBINFO='${OV_RELWITHDEBINFO_C_FLAGS}' \
+                  -DCMAKE_CXX_FLAGS_RELWITHDEBINFO='${OV_RELWITHDEBINFO_CXX_FLAGS}' \
                   -DTREAT_WARNING_AS_ERROR=FALSE \
                   -DENABLE_DATA=FALSE \
                   -DENABLE_SYSTEM_GFLAGS=ON \


### PR DESCRIPTION
Add an opt-in recipe knob to reduce DWARF size while keeping RelWithDebInfo as the default build type.

Changes:
- Add OV_CMAKE_BUILD_TYPE overridable (default: RelWithDebInfo)
- Add OV_REDUCE_DEBUG_INFO (default: 0)
- When enabled, append -g1 -fdebug-types-section to CMAKE_{C,CXX}_FLAGS_RELWITHDEBINFO

To enable reduced debug info for this recipe:

```
# local.conf
OV_CMAKE_BUILD_TYPE:pn-openvino-inference-engine = "RelWithDebInfo"
OV_REDUCE_DEBUG_INFO:pn-openvino-inference-engine = "1"
```

Measured impact:

File/package sizes

| Metric | Before | After | Reduction |
|---|---:|---:|---:|
| openvino-inference-engine-dbg package | 2.27 GB | 527.5 MB | 76.7% |
| CPU plugin debug file | 1.32 GB | 313.3 MB | 76.2% |
| libopenvino debug file | 577.7 MB | 126.6 MB | 78.1% |
| libopenvino_c debug file | 7.3 MB | 1.3 MB | 82.1% |

CPU plugin DWARF section sizes

| Section | Before | After | Reduction |
|---|---:|---:|---:|
| .debug_info | 753.6 MB | 99.5 MB | 86.8% |
| .debug_loclists | 218.1 MB | 0.0 MB | 100.0% |
| .debug_str | 177.3 MB | 109.8 MB | 38.1% |
| .debug_line | 95.6 MB | 47.7 MB | 50.1% |
| .debug_rnglists | 36.3 MB | 25.7 MB | 29.1% |
