### PR TITLE
arm-compute-library: drop the os variable for arm

### DIFF
--- a/recipes-devtools/arm-compute-library/arm-compute-library_24.11.bb
+++ b/recipes-devtools/arm-compute-library/arm-compute-library_24.11.bb
@@ -39,7 +39,7 @@ PACKAGECONFIG[examples] = "examples=1,examples=0"
 EXTRA_OESCONS = "build=cross_compile os=linux toolchain_prefix=' ' extra_cxx_flags='-fPIC -O2' ${PACKAGECONFIG_CONFARGS}"
 
 EXTRA_OESCONS:append:aarch64 = " arch=arm64-v8a neon=1"
-EXTRA_OESCONS:append:arm = " os=webos neon=1 arch=armv7a${@ '-hf' if (d.getVar('TUNE_CCARGS_MFLOAT') == 'hard') else ''}"
+EXTRA_OESCONS:append:arm = " neon=1 arch=armv7a${@ '-hf' if (d.getVar('TUNE_CCARGS_MFLOAT') == 'hard') else ''}"
 EXTRA_OESCONS:append:x86 = " arch=x86_32 neon=0 estate=32"
 EXTRA_OESCONS:append:x86-64 = " arch=x86_64 neon=0"
 


### PR DESCRIPTION
With the env variable MACHINE ??= "qemuarm" setting, we encounter the following error: "
DEBUG: Executing shell function do_compile
scons: Reading SConscript files ...

scons: *** Invalid value for enum variable 'os': 'webos'. Valid values are: ('linux', 'android', 'tizen', 'macos', 'bare_metal', 'openbsd', 'windows') File "TOPDIR/tmp/work/cortexa15hf-neon-wrs-linux-gnueabi/arm-compute-library/24.11/sources/arm-compute-library-24.11/SConstruct", line 157, in <module> ERROR: scons build execution failed.
"

Meanwhile we can see the limitation in SConstruct file:
    EnumVariable("os", "Target OS. With bare metal selected, only Arm® Neon™ (not OpenCL) can be used,
                 static libraries get built and Neon™'s multi-threading support is disabled.", "linux",
                 allowed_values=("linux", "android", "tizen", "macos", "bare_metal", "openbsd","windows")),

So here we drop the invalid os definition.