### PR TITLE
openvino-inference-engine: always fetch all git sources regardless of PACKAGECONFIG

### DIFF
--- a/recipes-core/opencv/openvino-inference-engine_2025.4.2.bb
+++ b/recipes-core/opencv/openvino-inference-engine_2025.4.2.bb
@@ -9,6 +9,10 @@ SRC_URI = "git://github.com/openvinotoolkit/openvino.git;protocol=https;name=ope
            git://github.com/oneapi-src/oneDNN.git;protocol=https;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/src/plugins/intel_gpu/thirdparty/onednn_gpu;name=onednn;nobranch=1 \
            git://github.com/herumi/xbyak.git;protocol=https;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/thirdparty/xbyak;name=xbyak;branch=master \
            git://github.com/openvinotoolkit/mlas.git;protocol=https;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/src/plugins/intel_cpu/thirdparty/mlas;name=mlas;nobranch=1 \
+           git://github.com/openvinotoolkit/googletest.git;protocol=https;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/thirdparty/gtest/gtest;name=gtest;nobranch=1;lfs=0 \
+           git://github.com/openvinotoolkit/telemetry.git;protocol=https;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/thirdparty/telemetry;name=telemetry;nobranch=1;lfs=0 \
+           git://github.com/nodejs/node-addon-api.git;protocol=https;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/node-addon-api-src;name=node-addon-api;nobranch=1 \
+           git://github.com/onnx/onnx.git;protocol=https;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/thirdparty/onnx/onnx;name=onnx;branch=rel-1.17.0;lfs=0 \
            file://0001-cmake-yocto-specific-tweaks-to-the-build-process.patch \
            file://0002-cmake-Fix-overloaded-virtual-error.patch \
            file://0001-Fix-dependencies-to-use-system.patch \
@@ -18,6 +22,9 @@ SRC_URI = "git://github.com/openvinotoolkit/openvino.git;protocol=https;name=ope
            file://0001-Don-t-error-out-on-CI_BUILD_NUMBER-not-defined.patch \
            file://0005-Use-system-zlib.patch \
            file://0005-ittapi-prefer-system-ittnotify-over-bundled-source.patch \
+           file://0001-RecordProperty-serializes-ints-and-64-bit-ints-inclu.patch;patchdir=thirdparty/gtest/gtest \
+           file://0006-python-rename-benchmark_app-entry-point.patch \
+           file://0001-node-addon-use-system-node-api-headers.patch \
            "
 
 SRCREV_openvino = "85e49f27be1b1647a7ec331069b053596d1112f8"
@@ -25,7 +32,11 @@ SRCREV_mkl = "a4ed4a789b6e0869e4f651bbfeff6878e91d388e"
 SRCREV_onednn = "29d64fe0ec0f1f20d7f80aa76630d58a6011a869"
 SRCREV_xbyak = "0d67fd1530016b7c56f3cd74b3fca920f4c3e2b4"
 SRCREV_mlas = "d1bc25ec4660cddd87804fcf03b2411b5dfb2e94"
-SRCREV_FORMAT = "openvino_mkl_onednn_xbyak_mlas"
+SRCREV_gtest = "99760ac1776430f3df65947992bf4e8ebc0d7660"
+SRCREV_telemetry = "8abddc3dbc8beb04a39b5ea40cbba5020317102f"
+SRCREV_node-addon-api = "6babc960154752f686a7dca8e712991a976a754b"
+SRCREV_onnx = "b8baa8446686496da4cc8fda09f2b6fe65c2a02c"
+SRCREV_FORMAT = "openvino_mkl_onednn_xbyak_mlas_gtest_telemetry_node-addon-api_onnx"
 
 LICENSE = "Apache-2.0 & MIT & BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327 \
@@ -34,6 +45,10 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327 \
                     file://src/plugins/intel_cpu/thirdparty/mlas/LICENSE;md5=86d3f3a95c324c9479bd8986968f4327 \
                     file://src/plugins/intel_cpu/thirdparty/onednn/LICENSE;md5=3b64000f6e7d52516017622a37a94ce9 \
                     file://src/plugins/intel_gpu/thirdparty/onednn_gpu/LICENSE;md5=05fda7e0b3a0fe6749e8443316fc9a3f \
+                    file://thirdparty/gtest/gtest/LICENSE;md5=cbbd27594afd089daa160d3a16dd515a \
+                    file://thirdparty/telemetry/LICENSE;md5=86d3f3a95c324c9479bd8986968f4327 \
+                    file://node-addon-api-src/LICENSE.md;md5=fc3ff1120869be6b3cce17f9a06bfe2e \
+                    file://thirdparty/onnx/onnx/LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57 \
 "
 
 inherit cmake python3targetconfig pkgconfig qemu
@@ -111,15 +126,6 @@ PACKAGECONFIG[samples] = "-DENABLE_SAMPLES=ON -DENABLE_COMPILE_TOOL=ON, -DENABLE
 PACKAGECONFIG[verbose] = "-DVERBOSE_BUILD=1,-DVERBOSE_BUILD=0"
 PACKAGECONFIG[tests] = "-DENABLE_TESTS=ON, -DENABLE_TESTS=OFF, abseil-cpp,"
 
-SRC_URI += "${@bb.utils.contains('PACKAGECONFIG', 'tests', \
-    'git://github.com/openvinotoolkit/googletest.git;protocol=https;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/thirdparty/gtest/gtest;name=gtest;nobranch=1;lfs=0 \
-     file://0001-RecordProperty-serializes-ints-and-64-bit-ints-inclu.patch;patchdir=thirdparty/gtest/gtest', \
-    '', d)}"
-SRCREV_gtest = "99760ac1776430f3df65947992bf4e8ebc0d7660"
-SRCREV_FORMAT .= "${@bb.utils.contains('PACKAGECONFIG', 'tests', '_gtest', '', d)}"
-LIC_FILES_CHKSUM += "${@bb.utils.contains('PACKAGECONFIG', 'tests', \
-    'file://thirdparty/gtest/gtest/LICENSE;md5=cbbd27594afd089daa160d3a16dd515a', \
-    '', d)}"
 LDFLAGS:append = "${@bb.utils.contains('PACKAGECONFIG', 'tests', ' -Wl,--allow-shlib-undefined', '', d)}"
 
 # Frontends
@@ -129,35 +135,6 @@ PACKAGECONFIG[tflite] = "-DENABLE_OV_TF_LITE_FRONTEND=ON, -DENABLE_OV_TF_LITE_FR
 PACKAGECONFIG[paddle] = "-DENABLE_OV_PADDLE_FRONTEND=ON, -DENABLE_OV_PADDLE_FRONTEND=OFF, protobuf protobuf-native abseil-cpp,"
 PACKAGECONFIG[pytorch] = "-DENABLE_OV_PYTORCH_FRONTEND=ON, -DENABLE_OV_PYTORCH_FRONTEND=OFF,,"
 PACKAGECONFIG[jax] = "-DENABLE_OV_JAX_FRONTEND=ON, -DENABLE_OV_JAX_FRONTEND=OFF,,"
-
-SRC_URI += "${@bb.utils.contains('PACKAGECONFIG', 'python3', \
-    'git://github.com/openvinotoolkit/telemetry.git;protocol=https;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/thirdparty/telemetry;name=telemetry;nobranch=1;lfs=0 \
-     file://0006-python-rename-benchmark_app-entry-point.patch', \
-    '', d)}"
-SRCREV_telemetry = "8abddc3dbc8beb04a39b5ea40cbba5020317102f"
-SRCREV_FORMAT .= "${@bb.utils.contains('PACKAGECONFIG', 'python3', '_telemetry', '', d)}"
-LIC_FILES_CHKSUM += "${@bb.utils.contains('PACKAGECONFIG', 'python3', \
-    'file://thirdparty/telemetry/LICENSE;md5=86d3f3a95c324c9479bd8986968f4327', \
-    '', d)}"
-
-SRC_URI += "${@bb.utils.contains('PACKAGECONFIG', 'node', \
-    'git://github.com/nodejs/node-addon-api.git;protocol=https;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/node-addon-api-src;name=node-addon-api;nobranch=1 \
-     file://0001-node-addon-use-system-node-api-headers.patch', \
-    '', d)}"
-SRCREV_node-addon-api = "6babc960154752f686a7dca8e712991a976a754b"
-SRCREV_FORMAT .= "${@bb.utils.contains('PACKAGECONFIG', 'node', '_node-addon-api', '', d)}"
-LIC_FILES_CHKSUM += "${@bb.utils.contains('PACKAGECONFIG', 'node', \
-    'file://node-addon-api-src/LICENSE.md;md5=fc3ff1120869be6b3cce17f9a06bfe2e', \
-    '', d)}"
-
-SRC_URI += "${@bb.utils.contains('PACKAGECONFIG', 'onnx', \
-    'git://github.com/onnx/onnx.git;protocol=https;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/thirdparty/onnx/onnx;name=onnx;branch=rel-1.17.0;lfs=0', \
-    '', d)}"
-SRCREV_onnx = "b8baa8446686496da4cc8fda09f2b6fe65c2a02c"
-SRCREV_FORMAT .= "${@bb.utils.contains('PACKAGECONFIG', 'onnx', '_onnx', '', d)}"
-LIC_FILES_CHKSUM += "${@bb.utils.contains('PACKAGECONFIG', 'onnx', \
-    'file://thirdparty/onnx/onnx/LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57', \
-    '', d)}"
 
 do_configure:prepend() {
     # Note if no threading backend is selected in PACKAGECONFIG


### PR DESCRIPTION
… PACKAGECONFIG

Move gtest, telemetry, node-addon-api and onnx git sources out of bb.utils.contains() guards and into the unconditional SRC_URI. Update SRCREV_FORMAT and LIC_FILES_CHKSUM accordingly.

PACKAGECONFIG is designed to control configure/cmake arguments and DEPENDS/RDEPENDS (its six documented fields cover only these). Using inline python to conditionally modify SRC_URI, SRCREV_FORMAT and LIC_FILES_CHKSUM based on PACKAGECONFIG goes beyond this scope and couples the fetch phase to build-time configuration.

In practice this causes problems for downstream consumers that pre-populate DL_DIR via a single fetchall pass for offline or mirror-based builds. Sources gated behind PACKAGECONFIG are not fetched unless all options are explicitly enabled at fetch time. When the build configuration later changes, or when an automated rebase updates SRCREVs, the build fails due to missing sources. The dynamic SRCREV_FORMAT (.= with conditional fragments) also makes version upgrades fragile, as it is easy to miss updating SRCREVs hidden inside inline python expressions.

The additional fetch cost (~360 MB, mostly from the onnx repository) is modest relative to the ~3.2 GB of core sources already fetched unconditionally, and ensures DL_DIR remains complete regardless of PACKAGECONFIG.