### PR TITLE
openvino-inference-engine: fix intel_gpu duplicate opencl.hpp param t…

### DIFF
--- a/recipes-core/opencv/files/0007-intel-gpu-handle-opencl-hpp-1.1-param-traits-macro.patch
+++ b/recipes-core/opencv/files/0007-intel-gpu-handle-opencl-hpp-1.1-param-traits-macro.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Yogesh Tyagi <yogesh.tyagi@intel.com>
+Date: Wed, 11 Jun 2026 00:00:00 +0000
+Subject: [PATCH] intel_gpu: avoid duplicate opencl.hpp param traits
+
+With newer OpenCL C++ headers (opencl.hpp), the
+CL_HPP_PARAM_NAME_INFO_1_1_DEPRECATED_IN_2_0_ param traits are already
+declared by the header, so re-declaring them in ocl_wrapper.hpp produces
+duplicate-definition errors. Drop the redundant local declaration and
+rely on the ones provided by the OpenCL headers.
+
+Upstream-Status: Inappropriate [toolchain/header compatibility]
+
+Signed-off-by: Yogesh Tyagi <yogesh.tyagi@intel.com>
+---
+diff --git a/src/plugins/intel_gpu/src/runtime/ocl/ocl_wrapper.hpp b/src/plugins/intel_gpu/src/runtime/ocl/ocl_wrapper.hpp
+index 13f6eb7..5a2d7d1 100644
+--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_wrapper.hpp
++++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_wrapper.hpp
+@@ -75,7 +75,6 @@
+ #if CL_HPP_TARGET_OPENCL_VERSION >= 200 && CL_HPP_MINIMUM_OPENCL_VERSION >= 200
+ namespace cl {
+ namespace detail {
+-CL_HPP_PARAM_NAME_INFO_1_1_DEPRECATED_IN_2_0_(CL_HPP_DECLARE_PARAM_TRAITS_)
+ }
+ }
+ #endif

--- a/recipes-core/opencv/openvino-inference-engine_2025.4.2.bb
+++ b/recipes-core/opencv/openvino-inference-engine_2025.4.2.bb
@@ -18,6 +18,7 @@ SRC_URI = "git://github.com/openvinotoolkit/openvino.git;protocol=https;name=ope
            file://0001-Don-t-error-out-on-CI_BUILD_NUMBER-not-defined.patch \
            file://0005-Use-system-zlib.patch \
            file://0005-ittapi-prefer-system-ittnotify-over-bundled-source.patch \
+           file://0007-intel-gpu-handle-opencl-hpp-1.1-param-traits-macro.patch \
            "
 
 SRCREV_openvino = "85e49f27be1b1647a7ec331069b053596d1112f8"


### PR DESCRIPTION
…raits

Newer OpenCL C++ headers (opencl.hpp) already declare the CL_HPP_PARAM_NAME_INFO_1_1_DEPRECATED_IN_2_0_ param traits, so the local re-declaration in intel_gpu's ocl_wrapper.hpp causes duplicate-definition build errors. Add a patch dropping the redundant declaration.