### PR TITLE
recipes: use SPDX expression syntax for LICENSE

### DIFF
--- a/recipes-core/opencv/openvino-inference-engine_2025.4.2.bb
+++ b/recipes-core/opencv/openvino-inference-engine_2025.4.2.bb
@@ -29,7 +29,7 @@ SRCREV_xbyak = "0d67fd1530016b7c56f3cd74b3fca920f4c3e2b4"
 SRCREV_mlas = "d1bc25ec4660cddd87804fcf03b2411b5dfb2e94"
 SRCREV_FORMAT = "openvino_mkl_onednn_xbyak_mlas"
 
-LICENSE = "Apache-2.0 & MIT & BSD-3-Clause"
+LICENSE = "Apache-2.0 AND BSD-3-Clause AND MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327 \
                     file://thirdparty/xbyak/COPYRIGHT;md5=3c98edfaa50a86eeaef4c6109e803f16 \
                     file://thirdparty/cnpy/LICENSE;md5=689f10b06d1ca2d4b1057e67b16cd580 \

--- a/recipes-devtools/arm-compute-library/arm-compute-library_24.11.bb
+++ b/recipes-devtools/arm-compute-library/arm-compute-library_24.11.bb
@@ -1,6 +1,6 @@
 SUMMARY = "The ARM Computer Vision and Machine Learning library"
 DESCRIPTION = "The ARM Computer Vision and Machine Learning library is a set of functions optimised for both ARM CPUs and GPUs."
-LICENSE = "MIT & Apache-2.0"
+LICENSE = "Apache-2.0 AND MIT"
 LIC_FILES_CHKSUM = "file://LICENSES/Apache-2.0.txt;md5=b3fe88572da337dd5b13cafe9424e879 \
                     file://LICENSES/MIT.txt;md5=35f8944fae972976691f3483b0ac9dba \
                    "


### PR DESCRIPTION
oe-core now parses LICENSE as an SPDX license expression (commit e9d424738d) and warns at parse time about the legacy '&' operator.

Convert to canonical SPDX with alphabetically sorted operands (no change in actual licensing):
- openvino-inference-engine: 'Apache-2.0 & MIT & BSD-3-Clause' -> 'Apache-2.0 AND BSD-3-Clause AND MIT';
- arm-compute-library: 'MIT & Apache-2.0' -> 'Apache-2.0 AND MIT'.